### PR TITLE
Updated Proguard library to V7.5.0

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -211,6 +211,26 @@
       </libraryjar>
 
       <dontnote filter="proguard.configuration.ConfigurationLogger" />
+      <!-- These dontnote lines are using to skip duplicate classes note. -->
+      <dontnote filter="com.google.appinventor.components.**" />
+      <dontnote filter="org.json.**" />
+      <dontnote filter="com.google.gson.**" />
+      <dontnote filter="com.google.common.base.**" />
+      <dontnote filter="com.google.common.cache.**" />
+      <dontnote filter="com.google.common.collect.**" />
+      <dontnote filter="com.google.common.eventbus.**" />
+      <dontnote filter="com.google.common.hash.**" />
+      <dontnote filter="com.google.common.io.**" />
+      <dontnote filter="com.google.common.net.**" />
+      <dontnote filter="com.google.common.reflect.**" />
+      <dontnote filter="com.google.common.util.concurrent.**" />
+      <dontnote filter="android.net.http.**" />
+      <dontnote filter="org.apache.http.**" />
+      <dontnote filter="com.google.common.primitives.**" />
+      <dontnote filter="com.google.common.math.**" />
+      <dontnote filter="org.apache.commons.pool2.**" />
+      <dontnote filter="com.google.common.annotations.**" />
+      <dontnote filter="com.google.appinventor.common.version.**" />
       <adaptresourcefilecontents filter="proguard/ant/task.properties" />
     </proguard>
 


### PR DESCRIPTION
1. proguard.jar is updated to V7.5.0
2. Modified build.xml to skip duplicate classes notes from proguard task.